### PR TITLE
feat: add bazel shim

### DIFF
--- a/shims/bazel
+++ b/shims/bazel
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+# asdf-plugin: bazelisk
+
+exec bazelisk "$@"


### PR DESCRIPTION
Hey!

Firstly, thank you for providing asdf plugin for bazelisk. I find it very useful. One missing feature of this asdf plugin was a need to call "bazelisk" rather "bazel" every time. Normally, "bazel" command is symlinked to "bazelisk", but I am new to the asdf plugin ecosystem and found that this also gets the job done.

If you have a better approach to this, please let me know.

Best regards,
TheAifam5

```nu
🐱 ❯ : which bazelisk
╭───┬──────────┬──────────────────────────────────────┬──────────╮
│ # │ command  │                 path                 │   type   │
├───┼──────────┼──────────────────────────────────────┼──────────┤
│ 0 │ bazelisk │ /home/theaifam5/.asdf/shims/bazelisk │ external │
╰───┴──────────┴──────────────────────────────────────┴──────────╯

🐱 ❯ : cat /home/theaifam5/.asdf/shims/bazelisk
#!/usr/bin/env bash
# asdf-plugin: bazelisk 1.25.0
exec /home/theaifam5/.asdf/bin/asdf exec "bazelisk" "$@" # asdf_allow: ' asdf '

🐱 ❯ : which bazel
╭───┬─────────┬───────────────────────────────────┬──────────╮
│ # │ command │               path                │   type   │
├───┼─────────┼───────────────────────────────────┼──────────┤
│ 0 │ bazel   │ /home/theaifam5/.asdf/shims/bazel │ external │
╰───┴─────────┴───────────────────────────────────┴──────────╯

🐱 ❯ : cat /home/theaifam5/.asdf/shims/bazel
#!/usr/bin/env bash
# asdf-plugin: bazelisk 1.25.0
exec /home/theaifam5/.asdf/bin/asdf exec "bazel" "$@" # asdf_allow: ' asdf '

🐱 ❯ : bazelisk --version
bazel 8.0.0

🐱 ❯ : bazel --version
bazel 8.0.0
```